### PR TITLE
Update URL for homepage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,41 +1,41 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.14.0
+    rev: v2.31.1
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
 
   - repo: https://github.com/psf/black
-    rev: 21.5b0
+    rev: 22.1.0
     hooks:
       - id: black
         args: [--target-version=py37]
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.9.1
+    rev: 4.0.1
     hooks:
       - id: flake8
         additional_dependencies: [flake8-2020]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.8.0
+    rev: 5.10.1
     hooks:
       - id: isort
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.8.0
+    rev: v1.9.0
     hooks:
       - id: python-check-blanket-noqa
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.1.0
     hooks:
       - id: check-merge-conflict
       - id: check-toml
       - id: check-yaml
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.2.1
+    rev: v2.6.0
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/flake8-implicit-str-concat.svg)](https://pypi.org/project/flake8-implicit-str-concat)
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/flake8-implicit-str-concat.svg)](https://pypi.org/project/flake8-implicit-str-concat)
 [![PyPI downloads](https://img.shields.io/pypi/dm/flake8-implicit-str-concat.svg)](https://pypistats.org/packages/flake8-implicit-str-concat)
-[![GitHub](https://img.shields.io/github/license/keisheiled/flake8-implicit-str-concat.svg)](LICENSE)
+[![GitHub](https://img.shields.io/github/license/flake8-implicit-str-concat/flake8-implicit-str-concat.svg)](LICENSE)
 [![Code style: Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 This is a plugin for the Python code checking tool [Flake8](http://flake8.pycqa.org/) to

--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@
 [![GitHub](https://img.shields.io/github/license/flake8-implicit-str-concat/flake8-implicit-str-concat.svg)](LICENSE)
 [![Code style: Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
-This is a plugin for the Python code checking tool [Flake8](http://flake8.pycqa.org/) to
-encourage correct string literal concatenation.
+This is a plugin for the Python code-checking tool [Flake8](https://flake8.pycqa.org/)
+to encourage correct string literal concatenation.
 
 It looks for style problems like implicitly concatenated string literals on the same
-line (which can be introduced by the code formating tool
+line (which can be introduced by the code-formatting tool
 [Black](https://github.com/psf/black/issues/26)), or unnecessary plus operators for
 explicit string literal concatenation.
 
 ## Install
 
-```
+```sh
 pip install flake8-implicit-str-concat
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ module = "flake8_implicit_str_concat"
 description-file = "README.md"
 author = "Dylan Turner"
 author-email = "58230987+keisheiled@users.noreply.github.com"
-home-page = "https://github.com/keisheiled/flake8-implicit-str-concat"
+home-page = "https://github.com/flake8-implicit-str-concat/flake8-implicit-str-concat"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",


### PR DESCRIPTION
The repo is now in an org: https://github.com/flake8-implicit-str-concat

Also update pre-commit and some minor README updates.