### PR TITLE
Autoupdate pre-commit quarterly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,3 +39,6 @@ repos:
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]
+
+ci:
+  autoupdate_schedule: quarterly


### PR DESCRIPTION
I've added https://pre-commit.ci for this org.

It will autofix pre-commit for PRs, and also autoupdate the hooks on a schedule.

By default the autoupdate is weekly, but we don't need it that often. Quarterly is the longest option, and we can always update manually at any time.
