### PR TITLE
Remove the upper version bound on more-itertools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         additional_dependencies: [flake8-2020]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
 

--- a/README.md
+++ b/README.md
@@ -53,3 +53,9 @@ The plugin uses the prefix `ISC`, short for Implicit String Concatenation.
 | ISC001 | implicitly concatenated string literals on one line              |
 | ISC002 | implicitly concatenated string literals over continuation line   |
 | ISC003 | explicitly concatenated string should be implicitly concatenated |
+
+## Release Notes
+
+You can find the release notes on the
+[https://github.com/flake8-implicit-str-concat/flake8-implicit-str-concat/releases](releases
+page).

--- a/flake8_implicit_str_concat.py
+++ b/flake8_implicit_str_concat.py
@@ -19,7 +19,7 @@ else:
 
 
 __all__ = ["__version__", "Checker"]
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 _ERROR = Tuple[int, int, str, None]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 requires-python = "~=3.7"
 requires = [
-    "more-itertools >=8.0.2, <9; python_version <= '3.9'",
+    "more-itertools >=8.0.2; python_version <= '3.9'",
 ]
 
 [tool.flit.entrypoints."flake8.extension"]


### PR DESCRIPTION
This fixes #42. @hugovk in https://github.com/flake8-implicit-str-concat/flake8-implicit-str-concat/issues/42#issuecomment-1370271585 recommended we do this ; it'll ease compatibility downstream, as highlighted in https://iscinumpy.dev/post/bound-version-constraints/#tldr