### PR TITLE
Add support for Python 3.12 and drop EOL 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.9", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        python-version: ["pypy3.9", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
         os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.9", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        python-version: ["pypy3.9", "3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
           cache: pip
           cache-dependency-path: pyproject.toml
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v3.3.1
     hooks:
       - id: pyupgrade
-        args: [--py37-plus]
+        args: [--py38-plus]
 
   - repo: https://github.com/psf/black
     rev: 23.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
+    rev: v3.4.0
     hooks:
       - id: pyupgrade
         args: [--py38-plus]
@@ -25,22 +25,40 @@ repos:
     rev: v1.10.0
     hooks:
       - id: python-check-blanket-noqa
+      - id: python-no-log-warn
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
+      - id: check-case-conflict
       - id: check-merge-conflict
       - id: check-toml
       - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/tox-dev/pyproject-fmt
+    rev: 0.10.0
+    hooks:
+      - id: pyproject-fmt
+
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.13
+    hooks:
+      - id: validate-pyproject
+
+  - repo: https://github.com/tox-dev/tox-ini-fmt
+    rev: 1.3.0
+    hooks:
+      - id: tox-ini-fmt
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.6
+    rev: v3.0.0-alpha.9-for-vscode
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.1.1
+    rev: v1.3.0
     hooks:
       - id: mypy
         args: [--strict]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.8.0
+    rev: v3.10.1
     hooks:
       - id: pyupgrade
         args: [--py38-plus]
 
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.7.0
     hooks:
       - id: black
 
@@ -17,7 +17,7 @@ repos:
         args: [--add-import=from __future__ import annotations]
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
       - id: flake8
         additional_dependencies: [flake8-2020]
@@ -39,14 +39,14 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.3.0
+    rev: v1.4.1
     hooks:
       - id: mypy
         args: [--strict, --pretty, --show-error-codes]
         additional_dependencies: [more-itertools]
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 0.10.0
+    rev: 0.13.0
     hooks:
       - id: pyproject-fmt
 
@@ -56,12 +56,12 @@ repos:
       - id: validate-pyproject
 
   - repo: https://github.com/tox-dev/tox-ini-fmt
-    rev: 1.3.0
+    rev: 1.3.1
     hooks:
       - id: tox-ini-fmt
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.9-for-vscode
+    rev: v3.0.0
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,16 +10,17 @@ repos:
     hooks:
       - id: black
 
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        args: [--add-import=from __future__ import annotations]
+
   - repo: https://github.com/PyCQA/flake8
     rev: 6.0.0
     hooks:
       - id: flake8
         additional_dependencies: [flake8-2020]
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
@@ -36,6 +37,14 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.3.0
+    hooks:
+      - id: mypy
+        args: [--strict, --pretty, --show-error-codes]
+        additional_dependencies: [more-itertools]
+
   - repo: https://github.com/tox-dev/pyproject-fmt
     rev: 0.10.0
     hooks:
@@ -56,13 +65,6 @@ repos:
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]
-
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.3.0
-    hooks:
-      - id: mypy
-        args: [--strict]
-        additional_dependencies: [more-itertools]
 
 ci:
   autoupdate_schedule: quarterly

--- a/flake8_implicit_str_concat.py
+++ b/flake8_implicit_str_concat.py
@@ -6,11 +6,13 @@ introduced by Black.
 Forbid all explicitly concatenated strings, in favour of implicit concatenation.
 """
 
+from __future__ import annotations
+
 import ast
 import sys
 import tokenize
 from dataclasses import dataclass
-from typing import Iterable, List, Tuple
+from typing import Iterable, Tuple
 
 if sys.version_info >= (3, 10):
     from itertools import pairwise
@@ -62,7 +64,7 @@ class Checker:
     name = __name__
     version = __version__
     tree: ast.AST
-    file_tokens: List[tokenize.TokenInfo]
+    file_tokens: list[tokenize.TokenInfo]
 
     def run(self) -> Iterable[_ERROR]:
         yield from _implicit(self.file_tokens)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
-requires = ["flit_core >=3,<4"]
 build-backend = "flit_core.buildapi"
+requires = [
+  "flit_core<4,>=3",
+]
 
 [tool.flit.metadata]
 module = "flake8_implicit_str_concat"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Quality Assurance",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -26,7 +25,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Quality Assurance",
 ]
-requires-python = "~=3.7"
+requires-python = ">=3.8"
 requires = [
     "more-itertools >=8.0.2; python_version <= '3.9'",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint
-    py{py3, 312, 311, 310, 39, 38, 37}
+    py{py3, 312, 311, 310, 39, 38}
     mypy
 isolated_build = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,24 +1,27 @@
 [tox]
-envlist =
+requires =
+    tox>=4.2
+env_list =
     lint
-    py{py3, 312, 311, 310, 39, 38}
     mypy
-isolated_build = True
+    py{py3, 312, 311, 310, 39, 38}
 
 [testenv]
-deps = flake8
-allowlist_externals=bash
+deps =
+    flake8
+pass_env =
+    FORCE_COLOR
 commands =
-    # Unit tests
-    # TODO {envpython} -m pytest --cov TODO --cov tests {posargs}
-
-    # Simple sanity tests
     bash -c "flake8 --version | grep flake8_implicit_str_concat"
     bash -c "flake8 --help    | grep flake8_implicit_str_concat"
-passenv = FORCE_COLOR
+allowlist_externals =
+    bash
 
 [testenv:lint]
-deps = pre-commit
-commands = pre-commit run --all-files --show-diff-on-failure
 skip_install = true
-passenv = PRE_COMMIT_COLOR
+deps =
+    pre-commit
+pass_env =
+    PRE_COMMIT_COLOR
+commands =
+    pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
Changes proposed in this pull request:

 * Python 3.12 is in beta
 * Drop support for Python 3.7, EOL this month
   * https://devguide.python.org/versions/
   * https://peps.python.org/pep-0537/
 * Not planning a major bump, `requires-python = ">=3.8"` makes sure people get the right version
 * Also update some linting and type hints
