### PR TITLE
Release to PyPI using Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: Build package
+
+on:
+  push:
+  pull_request:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+  # Always build & lint package.
+  build-package:
+    name: Build & verify package
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: hynek/build-and-inspect-python-package@v2
+
+  # Publish to Test PyPI on every commit on main.
+  release-test-pypi:
+    name: Publish in-dev package to test.pypi.org
+    if: |
+      github.repository_owner == 'flake8-implicit-str-concat'
+      && github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: build-package
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download packages built by build-and-inspect-python-package
+        uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: dist
+
+      - name: Publish to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true
+          repository-url: https://test.pypi.org/legacy/
+
+  # Publish to PyPI on GitHub Releases.
+  release-pypi:
+    name: Publish to PyPI
+    # Only run for published releases.
+    if: |
+      github.repository_owner == 'flake8-implicit-str-concat'
+      && github.event.action == 'published'
+    runs-on: ubuntu-latest
+    needs: build-package
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download packages built by build-and-inspect-python-package
+        uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,66 +1,37 @@
 # Release Checklist
 
-- [ ] Get `main` to the appropriate code release state.
+- [ ] Check tests pass on
       [GitHub Actions](https://github.com/flake8-implicit-str-concat/flake8-implicit-str-concat/actions)
-      should be running cleanly for all merges to `main`.
-      [![GitHub Actions status](https://github.com/flake8-implicit-str-concat/flake8-implicit-str-concat/workflows/Test/badge.svg)](https://github.com/flake8-implicit-str-concat/flake8-implicit-str-concat/actions)
+      [![GitHub Actions status](https://github.com/flake8-implicit-str-concat/flake8-implicit-str-concat/actions/workflows/main.yml/badge.svg)](https://github.com/flake8-implicit-str-concat/flake8-implicit-str-concat/actions/workflows/main.yml)
 
-* [ ] Start from a freshly cloned repo and bump version number:
+- [ ] Update
+      [changelog](https://github.com/flake8-implicit-str-concat/flake8-implicit-str-concat/blob/main/CHANGELOG.md)
 
-```sh
-cd /tmp
-rm -rf flake8-implicit-str-concat
-git clone https://github.com/flake8-implicit-str-concat/flake8-implicit-str-concat
-cd flake8-implicit-str-concat
-edit flake8_implicit_str_concat.py
-```
+- [ ] Go to the
+      [Releases page](https://github.com/flake8-implicit-str-concat/flake8-implicit-str-concat/releases)
+      and
 
-- [ ] Commit and push:
+  - [ ] Click "Draft a new release"
 
-```sh
-git add flake8_implicit_str_concat.py
-git commit -m "bump version"
-git push
-```
+  - [ ] Click "Choose a tag"
 
-- [ ] (Optional) Create a distribution and release on **TestPyPI**:
+  - [ ] Type the next `X.Y.Z` version and select "**Create new tag: X.Y.Z** on publish"
 
-```sh
-python -m pip install -U pip build keyring twine
-rm -rf build dist
-python -m build
-python -m twine check --strict dist/* && python -m twine upload --repository testpypi dist/*
-```
+  - [ ] Leave the "Release title" blank (it will be autofilled)
 
-- [ ] (Optional) Check **test** installation:
+  - [ ] Click "Generate release notes" and amend as required
 
-```sh
-python -m pip uninstall -y flake8-implicit-str-concat
-python -m pip install -U -i https://test.pypi.org/simple/ flake8-implicit-str-concat --extra-index-url https://pypi.org/simple --pre
-python -m flake8 --version
-```
+  - [ ] Click "Publish release"
 
-- [ ] Create a distribution and release on **live PyPI**:
-
-```sh
-python -m pip install -U pip build keyring twine
-rm -rf build dist
-python -m build
-python -m twine check --strict dist/* && python -m twine upload -r pypi dist/*
-```
+- [ ] Check the tagged
+      [GitHub Actions build](https://github.com/flake8-implicit-str-concat/flake8-implicit-str-concat/actions/workflows/deploy.yml)
+      has deployed to
+      [PyPI](https://pypi.org/project/flake8-implicit-str-concat/#history)
 
 - [ ] Check installation:
 
-```sh
-python -m pip uninstall -y flake8-implicit-str-concat
-python -m pip install -U flake8-implicit-str-concat
-python -m flake8 --version
-```
-
-- [ ] Draft a new release:
-      https://github.com/flake8-implicit-str-concat/flake8-implicit-str-concat/releases/new
-
-- [ ] "Choose a tag" > enter new version (e.g. "0.4.0") > "Create new tag"
-- [ ] Leave "Release title" empty
-- [ ] Click "Generate release notes" and amend if needed
-- [ ] Publish release
+  ```bash
+  python -m pip uninstall -y flake8-implicit-str-concat \
+  && python -m pip install -U flake8-implicit-str-concat \
+  && flake8 --version | grep flake8_implicit_str_concat
+  ```


### PR DESCRIPTION
PyPI has introduced "Trusted Publishers", a method to release files from CI using OIDC and generated, short-lived tokens, rather than long-lived tokens on the developer's own machine. This is both safer, and makes releasing easier and more convenient.

https://docs.pypi.org/trusted-publishers/

This PR adds a workflow to deploy to PyPI for new GitHub releases.

It also deploys to Test PyPI on merges to `main`, to make sure the release machinery is well oiled.

I've set up the PyPIs with this:

<img width="507" alt="image" src="https://github.com/user-attachments/assets/cbbe07fd-b80b-41e2-ba3c-80bcd8a85a6f">

* https://test.pypi.org/manage/project/flake8-implicit-str-concat/settings/publishing/
* https://pypi.org/manage/project/flake8-implicit-str-concat/settings/publishing/

---

PEP 740 ("Index support for digital attestations") introduces signatures which links the PyPI package to the GitHub repo, and helps users verify the source and authenticity of packages. This is only available with Trusted Publishing.

PyPI is still implementing support, but we can already start using it, which should also help them test out.

* https://peps.python.org/pep-0740/
* https://github.com/pypa/gh-action-pypi-publish#generating-and-uploading-attestations
* https://github.com/pypi/warehouse/issues/15871

All we need to do to enable this is add:
```yml
        with:
          attestations: true
```

