### PR TITLE
Switch from Flit to Hatchling + hatch-vcs for dynamic versioning

### DIFF
--- a/flake8_implicit_str_concat.py
+++ b/flake8_implicit_str_concat.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 import ast
 import sys
 import tokenize
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable, Tuple
 
 if sys.version_info >= (3, 10):
     from itertools import pairwise
@@ -23,7 +23,7 @@ else:
 __all__ = ["__version__", "Checker"]
 __version__ = "0.4.0"
 
-_ERROR = Tuple[int, int, str, None]
+_ERROR = tuple[int, int, str, None]
 
 
 def _implicit(file_tokens: Iterable[tokenize.TokenInfo]) -> Iterable[_ERROR]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,17 @@
 [build-system]
-build-backend = "flit_core.buildapi"
+build-backend = "hatchling.build"
 requires = [
-  "flit-core<4,>=3",
+  "hatch-vcs",
+  "hatchling",
 ]
 
-[tool.flit.entrypoints."flake8.extension"]
-ISC = "flake8_implicit_str_concat:Checker"
-[tool.flit.metadata]
-module = "flake8_implicit_str_concat"
-description-file = "README.md"
-author = "Dylan Turner"
-author-email = "58230987+keisheiled@users.noreply.github.com"
-home-page = "https://github.com/flake8-implicit-str-concat/flake8-implicit-str-concat"
+[project]
+name = "flake8-implicit-str-concat"
+description = "Flake8 plugin to encourage correct string literal concatenation"
+readme = "README.md"
+license = { text = "MIT" }
+authors = [ { name = "Dylan Turner", email = "58230987+keisheiled@users.noreply.github.com" } ]
+requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Console",
@@ -20,20 +20,29 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
-  "Programming Language :: Python :: 3 :: Only",
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Topic :: Software Development :: Quality Assurance",
 ]
-requires-python = ">=3.9"
-requires = [
-  "more-itertools >=8.0.2; python_version <= '3.9'",
+dynamic = [ "version" ]
+dependencies = [
+  "more-itertools>=8.0.2; python_version<='3.9'",
 ]
+
+urls.Homepage = "https://github.com/flake8-implicit-str-concat/flake8-implicit-str-concat"
+
+entry-points."flake8.extension".ISC = "flake8_implicit_str_concat:Checker"
+
+[tool.hatch]
+version.source = "vcs"
+
+[tool.hatch.version.raw-options]
+local_scheme = "no-local-version"
 
 [tool.ruff]
 fix = true

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,8 @@ deps =
 pass_env =
     FORCE_COLOR
 commands =
-    bash -c "flake8 --version | grep flake8_implicit_str_concat"
-    bash -c "flake8 --help    | grep flake8_implicit_str_concat"
+    bash -c "flake8 --version | grep flake8-implicit-str-concat"
+    bash -c "flake8 --help    | grep flake8-implicit-str-concat"
 allowlist_externals =
     bash
 


### PR DESCRIPTION
Follow on from https://github.com/flake8-implicit-str-concat/flake8-implicit-str-concat/pull/59#issuecomment-2425012413.

This will give us a "local version" for development versions, like 0.4.1.dev46, so we'll have unique dev versions to upload to Test PyPI.

```console
❯ flake8 --version
7.1.1 (flake8-2020: 1.8.1, flake8-implicit-str-concat: 0.4.1.dev46, mccabe: 0.7.0, pycodestyle: 2.12.1, pyflakes: 3.2.0) CPython 3.13.0 on
Darwin
```
