### PR TITLE
Add support for Python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.11", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["pypy3.11", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:

--- a/flake8_implicit_str_concat.py
+++ b/flake8_implicit_str_concat.py
@@ -55,7 +55,11 @@ def _explicit(root_node: ast.AST) -> Iterable[_ERROR]:
         if isinstance(node, ast.BinOp)
         and isinstance(node.op, ast.Add)
         and all(
-            isinstance(operand, (ast.Str, ast.Bytes, ast.JoinedStr))
+            isinstance(operand, ast.JoinedStr)
+            or (
+                isinstance(operand, ast.Constant)
+                and isinstance(operand.value, (str, bytes))
+            )
             for operand in [node.left, node.right]
         )
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Topic :: Software Development :: Quality Assurance",
 ]
@@ -76,6 +77,9 @@ lint.ignore = [
   "UP038", # Makes code slower and more verbose
 ]
 lint.isort.required-imports = [ "from __future__ import annotations" ]
+
+[tool.pyproject-fmt]
+max_supported_python = "3.14"
 
 [tool.pytest.ini_options]
 testpaths = [ "tests" ]

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ env_list =
     cli
     lint
     mypy
-    py{py3, 313, 312, 311, 310, 39}
+    py{py3, 314, 313, 312, 311, 310, 39}
 
 [testenv]
 extras =


### PR DESCRIPTION
Following #69, this fixes https://github.com/flake8-implicit-str-concat/flake8-implicit-str-concat/issues/67.