### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,14 +14,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.11", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["pypy3.11", "3.10", "3.11", "3.12", "3.13"]
         os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
     rev: v1.16.1
     hooks:
       - id: mypy
-        additional_dependencies: [more-itertools, pytest]
+        additional_dependencies: [pytest]
 
   - repo: https://github.com/tox-dev/pyproject-fmt
     rev: v2.6.0

--- a/flake8_implicit_str_concat.py
+++ b/flake8_implicit_str_concat.py
@@ -9,16 +9,10 @@ Forbid all explicitly concatenated strings, in favour of implicit concatenation.
 from __future__ import annotations
 
 import ast
-import sys
 import tokenize
 from collections.abc import Iterable
 from dataclasses import dataclass
-
-if sys.version_info >= (3, 10):
-    from itertools import pairwise
-else:
-    from more_itertools import pairwise
-
+from itertools import pairwise
 
 __all__ = ["Checker", "__version__"]
 __version__ = "0.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ description = "Flake8 plugin to encourage correct string literal concatenation"
 readme = "README.md"
 license = { text = "MIT" }
 authors = [ { name = "Dylan Turner", email = "58230987+keisheiled@users.noreply.github.com" } ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Console",
@@ -21,7 +21,6 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -30,9 +29,6 @@ classifiers = [
   "Topic :: Software Development :: Quality Assurance",
 ]
 dynamic = [ "version" ]
-dependencies = [
-  "more-itertools>=8.0.2; python_version<='3.9'",
-]
 optional-dependencies.tests = [
   "pytest",
   "pytest-cov",

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ env_list =
     cli
     lint
     mypy
-    py{py3, 313, 312, 311, 310, 39}
+    py{py3, 313, 312, 311, 310}
 
 [testenv]
 extras =


### PR DESCRIPTION
I think we're close enough to the end-of-life to drop it:

* https://devguide.python.org/versions/
* https://peps.python.org/pep-0596/
