### PR TITLE
Update release checklist

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,4 +2,4 @@ changelog:
   exclude:
     authors:
       - dependabot
-      - pre-commit-ci
+      - pre-commit-ci[bot]

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,7 +11,7 @@
 
   - [ ] Click "Select tag"
 
-  - [ ] Type the next `X.Y.Z` version and select "Create new tag" then click "Create"
+  - [ ] Type the next `X.Y.Z` version, click "Create new tag" then "Create"
 
   - [ ] Leave the "Release title" blank (it will be autofilled)
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,9 +9,9 @@
       and
   - [ ] Click "Draft a new release"
 
-  - [ ] Click "Choose a tag"
+  - [ ] Click "Select tag"
 
-  - [ ] Type the next `X.Y.Z` version and select "**Create new tag: X.Y.Z** on publish"
+  - [ ] Type the next `X.Y.Z` version and select "Create new tag" then click "Create"
 
   - [ ] Leave the "Release title" blank (it will be autofilled)
 


### PR DESCRIPTION
The process is the same, but some of the buttons have different text.

Also update the pre-commit-ci name so it's still excluded from autogenerated release notes.